### PR TITLE
sensors: fix PWM available field.

### DIFF
--- a/src/sensors.hpp
+++ b/src/sensors.hpp
@@ -375,10 +375,22 @@ class Sensors :
             }
         }
 
+        void setAvailable(const DBusInstancePtr& instance) const
+        {
+            if (instance->getField(fieldAvailable)->isNull())
+            {
+                // Some sensors don't have the
+                // `sensorAvailabilityInterface`, e.g. fan PWM.
+                // Force set to true for them
+                setFieldAvailable(instance, true);
+            }
+        }
+
         void supplementByStaticFields(
             const DBusInstancePtr& instance) const override
         {
             this->setSensorName(instance);
+            this->setAvailable(instance);
             this->setStatus(instance);
             this->setState(instance);
             this->setGroup(instance);


### PR DESCRIPTION
The Fan PWM sensors hasn't
`xyz.openbmc_project.State.Decorator.Availability` interface, so the Available state is not determinated. It is requred to force set the Available field into true.

End-user-impact: Now Fan PWM sensors always provide `Available` field
                 that is set into `true`.