### PR TITLE
yaweb: add a way to force restart yaweb.service unit

### DIFF
--- a/yaweb.service.in
+++ b/yaweb.service.in
@@ -7,6 +7,7 @@ After=lighttpd.service
 [Service]
 ExecReload=kill -s HUP $MAINPID
 ExecStart=@MESON_INSTALL_PREFIX@/bin/yaweb
+Restart=always
 Type=simple
 WorkingDirectory=/home/root
 


### PR DESCRIPTION
If yaweb-service crashes there no way to force restart it. This patch brings that.

End-user-impact: None (internal systemd configuration)

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>