### PR TITLE
redfish: fix Id field.

### DIFF
--- a/src/core/route/redfish/node.hpp
+++ b/src/core/route/redfish/node.hpp
@@ -32,6 +32,7 @@ class IParameterizedNode
     virtual ~IParameterizedNode() = default;
 
     virtual const std::string getParameterValue() const = 0;
+    virtual const std::string& getNodeId() const = 0;
     virtual const entity::IEntity::ConditionsList
         getEntityCondition() const = 0;
     virtual const entity::IEntity::InstancePtr getTargetInstance() const = 0;
@@ -109,6 +110,11 @@ class ParameterizedNode : public IParameterizedNode
     const std::string getParameterValue() const override
     {
         return pnCtx->decodeUriSegment(value);
+    }
+
+    const std::string& getNodeId() const override
+    {
+        return value;
     }
 
     const entity::IEntity::InstancePtr getTargetInstance() const override

--- a/tools/redfish-gen/redfish_gen/redfish_node.py
+++ b/tools/redfish-gen/redfish_gen/redfish_node.py
@@ -406,7 +406,7 @@ class DynamicRedfishNode(RedfishNode):
         return ""
 
     def fieldIdGetterDefinition(self) -> str:
-        return "createAction<CallableGetter>(nameFieldId, std::bind(&ParameterizedNode<%s>::getParameterValue, this))," % self.classname()
+        return "createAction<CallableGetter>(nameFieldId, std::bind(&ParameterizedNode<%s>::getNodeId, this))," % self.classname()
 
     def parameter_template(self):
         if isinstance(self.node_parameter(), StaticNodeParameter):


### PR DESCRIPTION
According to the DMTF REDFISH 9.6.6 Id section `since URIs are constructed from the value of the Id property, the value shall not contain any RFC1738-defined unsafe characters`.

The patch fix tha way to populate the Id field. The value will be acquired from uri-path without uri-decoding.

End-user-impact: Now redfish Id field have valid value according to the
                 RFC1738

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>