### PR TITLE
Auto invalidate cache

### DIFF
--- a/src/core/connect/dbus_connect.cpp
+++ b/src/core/connect/dbus_connect.cpp
@@ -94,6 +94,15 @@ void DBusConnect::process()
             log<level::CRIT>("Fail to process DBus handlers",
                              entry("ERROR=%s", ex.what()),
                              entry("DESC=%s", ex.description()));
+            if (errno == -EIO || errno == -EBADMSG)
+            {
+                log<level::CRIT>(
+                    "DBus connection is corrupt. No way to continue processing "
+                    "with the current context.",
+                    entry("ERROR=%s", ex.what()),
+                    entry("DESC=%s", ex.description()));
+                exit(EXIT_FAILURE);
+            }
         }
     }
     log<level::DEBUG>("Finish task of dbus connection handler");

--- a/src/core/connect/dbus_connect.cpp
+++ b/src/core/connect/dbus_connect.cpp
@@ -4,6 +4,7 @@
 #include "dbus_connect.hpp"
 
 #include <systemd/sd-bus.h>
+#include <unistd.h>
 
 #include <core/connect/connect.hpp>
 #include <core/entity/dbus_query.hpp>
@@ -82,6 +83,7 @@ void DBusConnect::process()
 {
     while (alive.load())
     {
+        query::dbus::DBusInstance::cleanupInstacesWatchers();
         try
         {
             {

--- a/src/core/entity/dbus_query.cpp
+++ b/src/core/entity/dbus_query.cpp
@@ -816,10 +816,16 @@ void DBusQuery::registerObjectRemovingObserver(
                        const InterfaceList& removedInterfaces,
                        const std::string& sender) -> bool {
         const std::string& objectPathStr = objectPath.str;
+        const auto dbusQuery = dbusQueryWeak.lock();
+        if (!dbusQuery)
+        {
+            return false;
+        }
+
         try
         {
             const ServiceName serviceName =
-                dbusQueryWeak.lock()->getConnect()->getWellKnownServiceName(
+                dbusQuery->getConnect()->getWellKnownServiceName(
                     sender);
             auto instanceHash =
                 DBusInstance::getHash(serviceName, objectPathStr);
@@ -829,7 +835,7 @@ void DBusQuery::registerObjectRemovingObserver(
                 entry("SIGNAL=InterfaceRemoved"),
                 entry("DBUS_OBJ=%s", objectPathStr.c_str()));
 
-            if (!dbusQueryWeak.lock()->checkCriteria(
+            if (!dbusQuery->checkCriteria(
                     objectPath, removedInterfaces, serviceName))
             {
                 return false;

--- a/src/core/entity/dbus_query.cpp
+++ b/src/core/entity/dbus_query.cpp
@@ -291,6 +291,15 @@ DBusInstancePtr DBusQuery::createInstance(const ServiceName& serviceName,
         serviceName, objectPath, getSearchPropertiesMap(), getWeakPtr());
     for (const auto& interface : interfaces)
     {
+        if (getSearchPropertiesMap().find(interface) ==
+            getSearchPropertiesMap().end())
+        {
+            // specified interface not declared in EP configuration
+            log<level::DEBUG>("createInstance(): specified interface not "
+                              "found in the endpoint configuration",
+                              entry("DBUS_IFACE=%s", interface.c_str()));
+            continue;
+        }
         auto properties = instance->queryProperties(getConnect(), interface);
         instance->fillMembers(interface, properties);
     }

--- a/src/core/entity/entity.cpp
+++ b/src/core/entity/entity.cpp
@@ -385,6 +385,7 @@ IEntity::InstancePtr BaseEntity::mergeInstance(InstancePtr instance)
         return instance;
     }
     foundIt->second->supplementOrUpdate(instance);
+    foundIt->second->mergeInternalMetadata(instance);
     return foundIt->second;
 }
 

--- a/src/core/entity/entity.cpp
+++ b/src/core/entity/entity.cpp
@@ -311,9 +311,8 @@ const IEntity::EntityMemberPtr
 
 const IEntity::InstancePtr BaseEntity::getInstance(std::size_t hash) const
 {
-    mutex.lock();
+    std::lock_guard<std::mutex> lock(mutex);
     auto findInstanceIt = this->instances.find(hash);
-    mutex.unlock();
     if (findInstanceIt == instances.end())
     {
         return IEntity::InstancePtr();

--- a/src/core/entity/entity.hpp
+++ b/src/core/entity/entity.hpp
@@ -421,7 +421,8 @@ class BaseEntity : virtual public IEntity
             const MemberName&,
             const IEntity::IEntityMember::IInstance::FieldType&) override;
         void supplementOrUpdate(const InstancePtr&) override;
-
+        void mergeInternalMetadata(const InstancePtr&) override
+        {}
         bool hasField(const MemberName&) const override;
         bool checkCondition(const ConditionPtr) const override;
         const InstanceCollection

--- a/src/core/entity/entity.hpp
+++ b/src/core/entity/entity.hpp
@@ -8,15 +8,16 @@
 #include <core/exceptions.hpp>
 #include <phosphor-logging/log.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <variant>
 #include <vector>
-#include <atomic>
 
 namespace app
 {
@@ -506,6 +507,9 @@ class BaseEntity : virtual public IEntity
   protected:
     static void defaultLinkProvider(const IEntity::InstancePtr& supplement,
                                     const IEntity::InstancePtr& target);
+
+  private:
+    mutable std::mutex mutex;
 };
 
 template <typename TEntity>

--- a/src/core/entity/entity_interface.hpp
+++ b/src/core/entity/entity_interface.hpp
@@ -180,6 +180,12 @@ class IEntity
          * @return std::size_t hash value
          */
         virtual std::size_t getHash() const = 0;
+
+        virtual void verifyState()
+        {}
+
+        virtual void setUninitialized()
+        {}
     };
 
     /**
@@ -377,9 +383,48 @@ class IEntity
 };
 } // namespace entity
 
+template <typename TEnumEvent>
+class IEvent
+{
+  public:
+    using Subscriber = typename std::function<void(TEnumEvent)>;
+
+    virtual ~IEvent() = default;
+
+    /**
+     * @brief Add subscriber to observe query process events.
+     *
+     * @param[in] subscriber - the subscriber
+     */
+    virtual void addEventSubscriber(const Subscriber&&)
+    {
+        // default: skip
+    }
+
+  protected:
+    /**
+     * @brief Sends a signal to subscribers with specify TEnumEvent.
+     *
+     * @param[in] event - the type of event
+     */
+    virtual void emitEvent(TEnumEvent) const
+    {
+        // default: skip
+    }
+};
+
 namespace query
 {
-class IQuery
+
+enum class QueryEvent
+{
+    hasFailures,
+    instanceAdded,
+    instanceRemoved,
+    instanceUpdated,
+};
+
+class IQuery : public virtual IEvent<QueryEvent>
 {
   public:
     class QueryException : public app::core::exceptions::ObmcAppException

--- a/src/core/entity/entity_interface.hpp
+++ b/src/core/entity/entity_interface.hpp
@@ -163,7 +163,13 @@ class IEntity
             supplementOrUpdate(const MemberName&,
                                const IEntityMember::IInstance::FieldType&) = 0;
         virtual void supplementOrUpdate(const InstancePtr&) = 0;
-
+        /**
+         * @brief Merge internal metadata of IInstance that is defined by
+         *        implementation.
+         *
+         * @param InstancePtr    - Destination IInstance to copy metadata from.
+         */
+        virtual void mergeInternalMetadata(const InstancePtr&) = 0;
         virtual bool hasField(const MemberName&) const = 0;
         virtual bool checkCondition(const ConditionPtr) const = 0;
         virtual const InstanceCollection

--- a/src/core/entity/event.hpp
+++ b/src/core/entity/event.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2023, KNS Group LLC (YADRO)
+
+#pragma once
+
+#include <core/entity/entity_interface.hpp>
+
+#include <functional>
+#include <vector>
+
+namespace app
+{
+
+template <typename TEnumEvent>
+class Event : public virtual IEvent<TEnumEvent>
+{
+    using Subscriber = typename IEvent<TEnumEvent>::Subscriber;
+
+  public:
+    ~Event() override = default;
+
+    /**
+     * @brief Add subscriber to observe query process events.
+     *
+     * @note thread unsafe
+     *
+     * @param[in] subscriber - the subscriber
+     */
+    void addEventSubscriber(const Subscriber&& subscriber) override
+    {
+        subscribers.emplace_back(subscriber);
+    }
+
+  protected:
+    /**
+     * @brief Sends a signal to subscribers with specify TEnumEvent.
+     *
+     * @note thread unsafe
+     *
+     * @param[in] event - the type of event
+     */
+    void emitEvent(TEnumEvent event) const override
+    {
+        auto callback = [event](const Subscriber& callback) {
+            std::invoke(callback, event);
+        };
+        std::for_each(subscribers.begin(), subscribers.end(), callback);
+    }
+
+  private:
+    std::vector<Subscriber> subscribers;
+};
+
+} // namespace app

--- a/src/service/session.cpp
+++ b/src/service/session.cpp
@@ -409,6 +409,7 @@ void ConfigFile::readData()
 {
     static std::mutex m;
     std::lock_guard<std::mutex> lock(m);
+    for (const auto& [storageType, sotrageMetaData] : configFilePathDict)
     {
         readData(storageType, sotrageMetaData.first, sotrageMetaData.second);
     }
@@ -416,7 +417,7 @@ void ConfigFile::readData()
 
 void ConfigFile::commit()
 {
-    for (auto& [storageType, sotrageMetaData] : configFilePathDict)
+    for (const auto& [storageType, sotrageMetaData] : configFilePathDict)
     {
         writeData(storageType, sotrageMetaData.first, sotrageMetaData.second);
     }

--- a/src/service/session.cpp
+++ b/src/service/session.cpp
@@ -12,6 +12,7 @@
 
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <string_view>
 
 namespace app
@@ -406,7 +407,8 @@ ConfigFile::~ConfigFile()
 
 void ConfigFile::readData()
 {
-    for (auto& [storageType, sotrageMetaData] : configFilePathDict)
+    static std::mutex m;
+    std::lock_guard<std::mutex> lock(m);
     {
         readData(storageType, sotrageMetaData.first, sotrageMetaData.second);
     }
@@ -438,6 +440,7 @@ void ConfigFile::readData(const session::configFileStorageType storageType,
         if (data.is_discarded())
         {
             log<level::ERR>("Error parsing persistent data in json file");
+            return;
         }
         else
         {


### PR DESCRIPTION
The PR brings a way to provide via web-api a consistent data only

Igor Kononenko (9):
      core: fix: avoid excessive dbus-requests
      core: entity: add a way to invalidate cache
      entity: fix RebootRemainingProvider query.
      core: query: fix weak-pointer reference
      core: dbus: connect: fix a way to access to the dbus-resource
      core: dbus: avoid deadlocking state of dbus-connection
      core: dbus: protect watcher: add signal debounce
      core: fix threads sync by mutex.
      core: session: fix config loop
