### PR TITLE
Signal handling issues

### DIFF
--- a/src/core/connect/dbus_connect.cpp
+++ b/src/core/connect/dbus_connect.cpp
@@ -87,7 +87,7 @@ void DBusConnect::process()
                     10);
                 guard();
             }
-            std::this_thread::sleep_for(1ms);
+            std::this_thread::sleep_for(20ms);
         }
         catch (const sdbusplus::exception_t& ex)
         {

--- a/src/core/connect/dbus_connect.hpp
+++ b/src/core/connect/dbus_connect.hpp
@@ -87,7 +87,7 @@ class DBusConnect : protected IConnect
                     calledUnsafe = true;
                     return std::invoke(operation);
                 }
-                std::this_thread::sleep_for(priority * 20us);
+                std::this_thread::sleep_for(priority * 500us);
                 vocationThreadId = std::thread::id(0);
             }
             return std::invoke(operation);

--- a/src/core/entity/dbus_query.hpp
+++ b/src/core/entity/dbus_query.hpp
@@ -102,10 +102,10 @@ class DBusInstance final :
      *        not.
      */
     bool state;
-    /** @brief The EP configuration (properties, entity-members, formatters,
-     *         validators)
+    /** 
+     * @brief Interfaces list that actual for this instance 
      */
-    DBusPropertyEndpointMap targetProperties;
+    InterfaceList actualInterfaces;
     /**
      * @brief The weak-pointer to the query object that is obtained instace from
      *        dbus
@@ -142,20 +142,20 @@ class DBusInstance final :
      * @brief Construct a new DBusInstance object
      *
      * @param inServiceName         - The DBus service name
-     * @param inObjectPath          - the DBus object path
-     * @param targetPropertiesDict  - The EP configuration (properties,
-     *                                entity-members, formatters, validators)
+     * @param inObjectPath          - The DBus object path
+     * @param actualInterfaces      - Interfaces list that actual for this
+     *                                instance
      * @param queryObject           - The weak-pointer to the query that is
      *                                obtained dbus-object
      */
     explicit DBusInstance(const std::string& inServiceName,
                           const std::string& inObjectPath,
-                          const DBusPropertyEndpointMap& targetPropertiesDict,
+                          const InterfaceList& actualInterfaces,
                           const DBusQueryConstWeakPtr& queryObject,
                           bool state = false) noexcept :
         Entity::StaticInstance(inServiceName + inObjectPath),
         serviceName(inServiceName), objectPath(inObjectPath), state(state),
-        targetProperties(targetPropertiesDict), dbusQuery(queryObject)
+        actualInterfaces(actualInterfaces), dbusQuery(queryObject)
     {
         log<level::DEBUG>("Create DBus instance cache",
                           entry("DBUS_SVC=%s", inServiceName.c_str()),
@@ -566,6 +566,18 @@ class DBusQuery : public IQuery, public virtual Event<app::query::QueryEvent>
                           entry("COUNT=%ld", fields.size()));
         return std::forward<const QueryFields>(fields);
     }
+
+    /**
+     * @brief Get setters for specified interfaces.
+     *        The setters dictionary origin from endpoint dictionary
+     *
+     * @throw std::invalid_argument       - setters not found for the specified
+     *                                      interface
+     * @param interface                   - interface name
+     * @return const DBusPropertySetters& - setters for the interface properties
+     */
+    const DBusPropertySetters&
+        dbusPropertySetters(const InterfaceName& interface) const;
 
     void configure(std::reference_wrapper<IEntity> entity) override
     {


### PR DESCRIPTION
The patch fixes several issues:

- dbus: connect: increase timeout to watch dbus-signals
- core: query: change a way to verify target interfaces.
- graphql: fix exception catching of graphql-parser.
- core: query: Add RAII class of AccessGuard.